### PR TITLE
Implement mutation requests, in addition to original query request

### DIFF
--- a/src/GraphQl/Value.elm
+++ b/src/GraphQl/Value.elm
@@ -110,7 +110,7 @@ addArguments arguments =
   else
     arguments
       |> List.map joinGraphQlArgument
-      |> String.join ", "
+      |> Helpers.join
       |> Helpers.betweenParen
 
 joinGraphQlArgument : (String, String) -> String

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -27,3 +27,7 @@ betweenParen string =
 betweenNewline : String -> String
 betweenNewline =
   between "\n"
+
+join : List String -> String
+join list =
+  String.join ", " list


### PR DESCRIPTION
Attention, beaucoup de redite de code, puisque les fonction relatives aux deux messages Query et Mutation sont strictement les mêmes jusqu'à la toute dernière fonction (encodeQuery ou encodeMutation) qui inscrit selon le cas "query " ou "mutation " en début de requête.

### Suggestion
Je te propose qu'à terme, il y n'y ait qu'une unique chaîne de fonctions avec un message "RequestType" qui la parcours et gère le type de requête souhaitée :
```
type RequestType
  = Query
  | Mutation

request : RequestType -> String -> Value Root -> Decoder a -> Request a
request requestType endpoint query_ decoder =
  Request requestType endpoint query_ decoder Nothing
```