### PR TITLE
Adds queryArgs

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.2.0",
+    "version": "3.3.0",
     "summary": "GraphQL queries made easy in Elm!",
     "repository": "https://github.com/ghivert/elm-graphql.git",
     "license": "BSD3",

--- a/src/GraphQl.elm
+++ b/src/GraphQl.elm
@@ -95,6 +95,7 @@ sendRequest id msg decoder =
 @docs variable
 @docs input
 @docs nestedInput
+@docs queryArgs
 
 # Requests
 @docs Request


### PR DESCRIPTION
## queryArgs

This pull request adds the following to the **elm-graphql** api:

```elm
queryArgs : List ( String, Argument Query ) -> Argument Query
```

## But Why?

I have been working with a great WordPress graphQl plugin called `wp-graphql`. In this library the api for forming free text search queries is like this:

```js
posts(
  after: String
  first: Int
  before: String
  last: Int
  where: QueryArgs
): PostsConnection
```

which in practice looks like this.

```graphql
{
  posts(where: {search: "lovely cats"}){
    edges{
      node{
        slug
        title
      }
    }
  }
}
```


I was unable to form such a query with `3.2.0` with this PR I'm can 👊 

## Example in action

```elm
searchQuery : String -> Operation Query Variables
searchQuery term =
    GraphQl.named "searchQuery"
        [ GraphQl.field "posts"
            |> GraphQl.withArgument "where" (GraphQl.queryArgs [ ( "search", (GraphQl.string term) ) ])
            |> GraphQl.withSelectors
                [ GraphQl.field "edges"
                    |> GraphQl.withSelectors
                        [ GraphQl.field "node"
                            |> GraphQl.withSelectors
                                [ GraphQl.field "slug"
                                ]
                        ]
                ]
        ]
        |> GraphQl.withVariables []
```

Would you consider this PR to give me and other developers the ability to form this kind of query? You can read more about the WordPress graphql library here:

https://github.com/wp-graphql/wp-graphql

Many thanks
@bmordan
